### PR TITLE
Simplify dev environment: drop ETL, cleanup Makefile, improve README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,37 @@
-# Build the docker images contained in this repo
+# Makefile
+# Build and run local stack for Pyronear
+
+SHELL := /bin/sh
+COMPOSE := docker compose
+
+.PHONY: help init build build-external build-all run-backend run-engine run-tools run run-all stop ps logs test
+
+help:
+	@echo "Targets:"
+	@echo "  init            Create .env from .env.test if missing"
+	@echo "  build           Build local images in this repo"
+	@echo "  build-external  Build images in sibling repos"
+	@echo "  build-all       Build local and external images"
+	@echo "  run-backend     Start base services without profiles"
+	@echo "  run-engine      Start engine profile only"
+	@echo "  run-tools       Start tools profile only"
+	@echo "  run             Start everything except engine"
+	@echo "  run-all         Start everything including engine"
+	@echo "  stop            Stop and remove all services and volumes"
+	@echo "  ps              Show compose status"
+	@echo "  logs            Follow logs"
+	@echo "  test            Run pytest"
+
+# -------------------------------------------------------------------
+# Init
+# -------------------------------------------------------------------
+
+init:
+	@test -f .env || cp .env.test .env
+
+# -------------------------------------------------------------------
+# Build images in this repo
+# -------------------------------------------------------------------
 
 build:
 	docker build -f containers/init_script/Dockerfile -t pyronear/pyro-api-init:latest containers/init_script/
@@ -6,36 +39,51 @@ build:
 	docker build -f containers/reolinkdev2/Dockerfile -t pyronear/reolinkdev2:latest containers/reolinkdev2/
 	docker build -f containers/notebooks/Dockerfile -t pyronear/notebooks:latest containers/notebooks/
 
-build-external:
-	cd ../pyro-api/; make build
-	cd ../pyro-engine/; make build-lib
-	cd ../pyro-engine/; make build-app
-	cd ../pyro-platform/; make build
+# -------------------------------------------------------------------
+# Build images from sibling repositories
+# -------------------------------------------------------------------
 
+build-external:
+	cd ../pyro-api && make build
+	cd ../pyro-engine && make build-lib
+	cd ../pyro-engine && make build-app
+	cd ../pyro-platform && make build
 
 build-all: build build-external
 
+# -------------------------------------------------------------------
+# Run targets
+# -------------------------------------------------------------------
+
 run-backend:
-	docker compose up -d
+	$(COMPOSE) up -d
 
 run-engine:
-	docker compose --profile engine up -d
+	$(COMPOSE) --profile engine up -d
 
 run-tools:
-	cp .env.test .env
-	docker compose --profile tools up -d
+	$(COMPOSE) --profile tools up -d
 
-run-etl:
-	docker compose --profile etl up -d
-
+# Start everything except the engine: base services plus front + tools
 run:
-	docker compose --profile front up -d
+	$(COMPOSE) --profile front --profile tools up -d
 
+# Start everything including the engine
 run-all:
-	docker compose --profile front --profile engine up -d
+	$(COMPOSE) --profile front --profile tools --profile engine up -d
 
 stop:
-	docker compose --profile front --profile engine --profile etl --profile tools down -v
+	$(COMPOSE) --profile front --profile engine --profile tools down -v
+
+ps:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs -f --tail=200
+
+# -------------------------------------------------------------------
+# Tests
+# -------------------------------------------------------------------
 
 test:
 	pytest -s tests/*

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 # Makefile
 # Build and run local stack for Pyronear
 
-SHELL := /bin/sh
-COMPOSE := docker compose
-
-.PHONY: help init build build-external build-all run-backend run-engine run-tools run run-all stop ps logs test
-
 help:
 	@echo "Targets:"
 	@echo "  init            Create .env from .env.test if missing"
@@ -56,30 +51,30 @@ build-all: build build-external
 # -------------------------------------------------------------------
 
 run-backend:
-	$(COMPOSE) up -d
+	docker compose  up -d
 
 run-engine:
-	$(COMPOSE) --profile engine up -d
+	docker compose  --profile engine up -d
 
 run-tools:
-	$(COMPOSE) --profile tools up -d
+	docker compose  --profile tools up -d
 
 # Start everything except the engine: base services plus front + tools
 run:
-	$(COMPOSE) --profile front --profile tools up -d
+	docker compose  --profile front --profile tools up -d
 
 # Start everything including the engine
 run-all:
-	$(COMPOSE) --profile front --profile tools --profile engine up -d
+	docker compose  --profile front --profile tools --profile engine up -d
 
 stop:
-	$(COMPOSE) --profile front --profile engine --profile tools down -v
+	docker compose  --profile front --profile engine --profile tools down -v
 
 ps:
-	$(COMPOSE) ps
+	docker compose  ps
 
 logs:
-	$(COMPOSE) logs -f --tail=200
+	docker compose  logs -f --tail=200
 
 # -------------------------------------------------------------------
 # Tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile
-# Build and run local stack for Pyronear
+# Build and run the local stack for Pyronear
 
 help:
 	@echo "Targets:"
@@ -7,11 +7,11 @@ help:
 	@echo "  build           Build local images in this repo"
 	@echo "  build-external  Build images in sibling repos"
 	@echo "  build-all       Build local and external images"
-	@echo "  run-backend     Start base services without profiles"
-	@echo "  run-engine      Start engine profile only"
-	@echo "  run-tools       Start tools profile only"
-	@echo "  run             Start everything except engine"
-	@echo "  run-all         Start everything including engine"
+	@echo "  run-backend     Start base services only"
+	@echo "  run-engine      Start base services plus engine profile"
+	@echo "  run-tools       Start base services plus tools profile"
+	@echo "  run             Start base services plus front and tools profiles"
+	@echo "  run-all         Start base services plus front tools and engine profiles"
 	@echo "  stop            Stop and remove all services and volumes"
 	@echo "  ps              Show compose status"
 	@echo "  logs            Follow logs"
@@ -50,31 +50,34 @@ build-all: build build-external
 # Run targets
 # -------------------------------------------------------------------
 
+# Base services: db, minio, pyro_api, init_script
 run-backend:
-	docker compose  up -d
+	docker compose up -d
 
+# Engine profile adds pyro_engine, reolinkdev1, reolinkdev2
 run-engine:
-	docker compose  --profile engine up -d
+	docker compose --profile engine up -d
 
+# Tools profile adds notebooks, db-ui
 run-tools:
-	docker compose  --profile tools up -d
+	docker compose --profile tools up -d
 
-# Start everything except the engine: base services plus front + tools
+# Front profile adds frontend, here we also include tools
 run:
-	docker compose  --profile front --profile tools up -d
+	docker compose --profile front --profile tools up -d
 
-# Start everything including the engine
+# Everything including engine
 run-all:
-	docker compose  --profile front --profile tools --profile engine up -d
+	docker compose --profile front --profile tools --profile engine up -d
 
 stop:
-	docker compose  --profile front --profile engine --profile tools down -v
+	docker compose --profile front --profile engine --profile tools down -v
 
 ps:
-	docker compose  ps
+	docker compose ps
 
 logs:
-	docker compose  logs -f --tail=200
+	docker compose logs -f --tail=200
 
 # -------------------------------------------------------------------
 # Tests

--- a/README.md
+++ b/README.md
@@ -109,14 +109,6 @@ docker logs engine
 
 ## 📂 Data Usage
 
-### Update the last image for a camera
-
-1. Upload a new image in MinIO under the bucket ending with `...-alert-api-{organisation_id}`
-2. In pgAdmin, update the `cameras` table:
-
-   * `last_image` with the filename
-   * `last_active_at` timestamp
-
 ### Add more images to Reolink Dev
 
 Create a directory `data/images` before starting the environment and put your images inside.
@@ -128,6 +120,16 @@ When running notebooks **inside Docker**, set:
 
 ```python
 API_URL = "http://api:5050"
+
+### Update the last image for a camera
+
+1. Upload a new image in MinIO under the bucket ending with `...-alert-api-{organisation_id}`
+2. In pgAdmin, update the `cameras` table:
+
+   * `last_image` with the filename
+   * `last_active_at` timestamp
+
+
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ This repository provides a Docker Compose configuration to run a full Pyronear d
 
 ---
 
+## ⚙️ Installation
+
+### Prerequisites
+
+* Docker and Docker Compose
+* Add this line to `/etc/hosts` so the MinIO endpoint resolves correctly:
+
+  ```
+  127.0.0.1 minio
+  ```
+
+---
+
 ## 🚀 Quick Start
 
 ### Init
@@ -36,20 +49,6 @@ make run
 * **reolinkdev1 / reolinkdev2**: Fake Reolink cameras sending test images
 * **notebooks**: Jupyter server to run helper notebooks
 * **db-ui**: pgAdmin to browse/manage the database
-
----
-
-## ⚙️ Installation
-
-### Prerequisites
-
-* Docker and Docker Compose
-* Pre-commit hook installed in this repo
-* Add this line to `/etc/hosts` so the MinIO endpoint resolves correctly:
-
-  ```
-  127.0.0.1 minio
-  ```
 
 ---
 


### PR DESCRIPTION
## Summary

This PR removes the unused ETL service and simplifies the developer workflow.

### Changes

* **Removed ETL**

  * Dropped `etl_scripts` service from `docker-compose.yml`
  * Removed `run-etl` and ETL references from Makefile
* **Makefile**

  * Added `init` target for `.env` creation (run once)
  * Simplified `run` (frontend + tools) and `run-all` (frontend + tools + engine)
  * Reordered and cleaned up targets for clarity
* **README**

  * Added a **Quick Start** section with minimal commands:

    ```bash
    make init
    make build
    make run
    ```
  * Updated instructions to send alerts via Jupyter notebooks and view them in the frontend or API
  * Documented services, access URLs, and credentials
  * Removed all ETL references



