### PR TITLE
feat: add temporal model API service

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -22,6 +22,12 @@ S3_REGION=us-east-1
 DB_UI_MAIL=dummy@pyronear.com
 DB_UI_PWD=strong-password
 
+# Temporal model validation gate (pyro-api PR #615).
+# Empty = disabled (pyro-api fails open). To enable, run the `temporal` profile
+# and set the URL to the service: http://temporal_model_api:8000
+TEMPORAL_API_URL=
+TEMPORAL_MODEL_THRESHOLD=0.45
+
 # only usefull to download some real sequences from real/distant Pyronear alert API
 DISTANT_API_URL=''
 DISTANT_ALERT_API_LOGIN=''

--- a/.env.test
+++ b/.env.test
@@ -27,6 +27,10 @@ DB_UI_PWD=strong-password
 # and set the URL to the service: http://temporal_model_api:8000
 TEMPORAL_API_URL=
 TEMPORAL_MODEL_THRESHOLD=0.45
+# Shared bearer token for the temporal API. Empty = auth disabled on both the
+# server (temporal_model_api) and the client (pyro-api). Set the same value to
+# require a token.
+TEMPORAL_API_TOKEN=
 
 # only usefull to download some real sequences from real/distant Pyronear alert API
 DISTANT_API_URL=''

--- a/.env.test
+++ b/.env.test
@@ -23,13 +23,13 @@ DB_UI_MAIL=dummy@pyronear.com
 DB_UI_PWD=strong-password
 
 # Temporal model validation gate (pyro-api PR #615).
-# Empty = disabled (pyro-api fails open). To enable, run the `temporal` profile
-# and set the URL to the service: http://temporal_model_api:8000
+# Empty = disabled (pyro-api fails open). `make run-temporal` auto-sets this to
+# http://temporal_model_api:8000; set it here only to enable via other targets.
 TEMPORAL_API_URL=
 TEMPORAL_MODEL_THRESHOLD=0.45
 # Shared bearer token for the temporal API. Empty = auth disabled on both the
-# server (temporal_model_api) and the client (pyro-api). Set the same value to
-# require a token.
+# server (temporal_model_api) and the client (pyro-api). `make run-temporal`
+# auto-sets a dev token; set the same value here to require auth on other targets.
 TEMPORAL_API_TOKEN=
 
 # only usefull to download some real sequences from real/distant Pyronear alert API

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "  run-tools-and-engine  Start base services plus tools and engine profiles"
 	@echo "  run-tools           Start base services plus tools profile"
 	@echo "  run                 Start base services plus front and tools profiles"
-	@echo "  run-temporal        Start base services plus temporal model API"
+	@echo "  run-temporal        Same as run (front + tools) plus temporal model API"
 	@echo "  stop-temporal       Stop only the temporal model API"
 	@echo "  stop-engine         Stop only engine services (engine + pyro_camera_api)"
 	@echo "  restart-engine      Restart engine services without re-running init_script"
@@ -72,9 +72,9 @@ run-tools:
 run:
 	docker compose --profile front --profile tools up -d
 
-# Temporal profile adds the temporal model API (reads alert images from MinIO)
+# Same as `run` (front + tools) plus the temporal model API
 run-temporal:
-	docker compose --profile temporal up -d
+	docker compose --profile front --profile tools --profile temporal up -d
 
 stop-temporal:
 	docker compose --profile temporal stop temporal_model_api

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,11 @@ run-tools:
 run:
 	docker compose --profile front --profile tools up -d
 
-# Same as `run` (front + tools) plus the temporal model API
+# Same as `run` (front + tools) plus the temporal model API, with auth enabled.
+# A shared token is passed to both services (override: TEMPORAL_API_TOKEN=... make run-temporal).
+TEMPORAL_API_TOKEN ?= dev-temporal-token
 run-temporal:
-	docker compose --profile front --profile tools --profile temporal up -d
+	TEMPORAL_API_TOKEN=$(TEMPORAL_API_TOKEN) docker compose --profile front --profile tools --profile temporal up -d
 
 stop-temporal:
 	docker compose --profile temporal stop temporal_model_api

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,13 @@ run-tools:
 run:
 	docker compose --profile front --profile tools up -d
 
-# Same as `run` (front + tools) plus the temporal model API, with auth enabled.
-# A shared token is passed to both services (override: TEMPORAL_API_TOKEN=... make run-temporal).
+# Same as `run` (front + tools) plus the temporal model API, with validation + auth enabled.
+# Points pyro-api at the temporal service and shares a token with both.
+# Override either: TEMPORAL_API_URL=... TEMPORAL_API_TOKEN=... make run-temporal
+TEMPORAL_API_URL ?= http://temporal_model_api:8000
 TEMPORAL_API_TOKEN ?= dev-temporal-token
 run-temporal:
-	TEMPORAL_API_TOKEN=$(TEMPORAL_API_TOKEN) docker compose --profile front --profile tools --profile temporal up -d
+	TEMPORAL_API_URL=$(TEMPORAL_API_URL) TEMPORAL_API_TOKEN=$(TEMPORAL_API_TOKEN) docker compose --profile front --profile tools --profile temporal up -d
 
 stop-temporal:
 	docker compose --profile temporal stop temporal_model_api

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ help:
 	@echo "  run-tools-and-engine  Start base services plus tools and engine profiles"
 	@echo "  run-tools           Start base services plus tools profile"
 	@echo "  run                 Start base services plus front and tools profiles"
+	@echo "  run-temporal        Start base services plus temporal model API"
+	@echo "  stop-temporal       Stop only the temporal model API"
 	@echo "  stop-engine         Stop only engine services (engine + pyro_camera_api)"
 	@echo "  restart-engine      Restart engine services without re-running init_script"
 	@echo "  stop                Stop and remove all services and volumes"
@@ -70,6 +72,13 @@ run-tools:
 run:
 	docker compose --profile front --profile tools up -d
 
+# Temporal profile adds the temporal model API (reads alert images from MinIO)
+run-temporal:
+	docker compose --profile temporal up -d
+
+stop-temporal:
+	docker compose --profile temporal stop temporal_model_api
+
 stop-engine:
 	docker compose --profile engine stop engine pyro_camera_api
 
@@ -77,7 +86,7 @@ restart-engine: stop-engine
 	docker compose --profile engine up -d engine pyro_camera_api --no-deps
 
 stop:
-	docker compose --profile front --profile engine --profile tools down -v
+	docker compose --profile front --profile engine --profile tools --profile temporal down -v
 
 ps:
 	docker compose ps

--- a/containers/init_script/requirements.txt
+++ b/containers/init_script/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 boto3==1.34.90
 requests
 pillow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,11 @@ services:
     - S3_ACCESS_KEY=${S3_ACCESS_KEY}
     - S3_SECRET_KEY=${S3_SECRET_KEY}
     - S3_REGION=${S3_REGION}
+    - SERVER_NAME=${SERVER_NAME}
     - PLATFORM_URL=${PLATFORM_URL:-http://0.0.0.0:8050}
     - TEMPORAL_API_URL=${TEMPORAL_API_URL:-}
     - TEMPORAL_MODEL_THRESHOLD=${TEMPORAL_MODEL_THRESHOLD:-0.45}
+    - TEMPORAL_API_TOKEN=${TEMPORAL_API_TOKEN:-}
     healthcheck:
       test: ["CMD-SHELL", "curl -X 'GET' 'http://pyro_api:5050/status' -H 'accept: application/json'"]
       interval: 20s
@@ -106,6 +108,8 @@ services:
       - TEMPORAL_API_S3_REGION=${S3_REGION}
       - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
       - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
+      # Empty = auth disabled; set the same value as pyro-api to require a token.
+      - TEMPORAL_API_TOKEN=${TEMPORAL_API_TOKEN:-}
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,23 @@ services:
         max-size: 100m
         max-file: '5'
 
+  temporal_model_api:
+    container_name: temporal_model_api
+    image: pyronear/temporal-model-api:latest
+    profiles:
+      - temporal
+    ports:
+      - 8000:8000
+    environment:
+      - TEMPORAL_API_S3_BUCKET=frames
+      - TEMPORAL_API_S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+      - TEMPORAL_API_S3_REGION=${S3_REGION}
+      - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}
+      - AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}
+    depends_on:
+      minio:
+        condition: service_healthy
+
   etl_scripts:
     container_name: etl
     image: pyronear/pyro-etl:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     - S3_SECRET_KEY=${S3_SECRET_KEY}
     - S3_REGION=${S3_REGION}
     - PLATFORM_URL=${PLATFORM_URL:-http://0.0.0.0:8050}
+    - TEMPORAL_API_URL=${TEMPORAL_API_URL:-}
+    - TEMPORAL_MODEL_THRESHOLD=${TEMPORAL_MODEL_THRESHOLD:-0.45}
     healthcheck:
       test: ["CMD-SHELL", "curl -X 'GET' 'http://pyro_api:5050/status' -H 'accept: application/json'"]
       interval: 20s
@@ -99,7 +101,7 @@ services:
     ports:
       - 8000:8000
     environment:
-      - TEMPORAL_API_S3_BUCKET=frames
+      # Bucket is supplied per request by pyro-api (per-org alert buckets).
       - TEMPORAL_API_S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
       - TEMPORAL_API_S3_REGION=${S3_REGION}
       - AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 psycopg2-binary==2.9.9
-pytest==8.1.1
-python-dotenv==1.0.1
+pytest==9.0.3
+python-dotenv==1.2.2
 boto3==1.34.90


### PR DESCRIPTION
- Add `temporal_model_api` (`pyronear/temporal-model-api:latest`) under a new `temporal` profile, wired to the existing MinIO so it can read alert-API images from S3. Uses `latest` so a locally built image is picked up.
- Add `make run-temporal` / `stop-temporal` targets and include the profile in `make stop`.
- Bucket is set to `frames` via `TEMPORAL_API_S3_BUCKET`; change that var if the alert API uses a different bucket.