### PR TITLE
fix: drop the /etc/hosts requirement by setting S3_PROXY_URL

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -18,6 +18,10 @@ S3_ENDPOINT_URL=http://minio:9000
 S3_ACCESS_KEY=JANE_DOE
 S3_SECRET_KEY=JANE_DOE
 S3_REGION=us-east-1
+# Public S3 endpoint: `minio` above only resolves inside the compose network, but
+# presigned URLs are opened by the browser. Works because boto3 presigns with SigV2,
+# which ignores the Host -- a SigV4 backend would need a Host-rewriting proxy.
+S3_PROXY_URL=http://localhost:9000
 
 # Prefix used by pyro-api to build per-org S3 bucket names. Must be a valid
 # bucket-name prefix (lowercase letters, digits, hyphens). Empty => InvalidBucketName.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ This repository provides a Docker Compose configuration to run a full Pyronear d
 ### Prerequisites
 
 * Docker and Docker Compose
-*  Add this line to your hosts file (`/etc/hosts` on Linux/macOS, `C:\Windows\System32\drivers\etc\hosts` on Windows):
-  ```
-  127.0.0.1 minio
-  ```
+
+> **Upgrading?** The `127.0.0.1 minio` hosts entry is no longer needed (`S3_PROXY_URL`
+> replaces it) — harmless if left in place, but you can remove it.
 
 ---
 
@@ -104,6 +103,9 @@ docker logs engine
 * **MinIO console (S3 GUI)**: [http://localhost:9001](http://localhost:9001)
 
   * Manage buckets, upload/delete files
+* **MinIO S3 API**: `minio:9000` from the compose network (`S3_ENDPOINT_URL`),
+  [http://localhost:9000](http://localhost:9000) from the host (`S3_PROXY_URL`, used
+  for presigned image URLs)
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     - S3_ACCESS_KEY=${S3_ACCESS_KEY}
     - S3_SECRET_KEY=${S3_SECRET_KEY}
     - S3_REGION=${S3_REGION}
+    # Host used in presigned URLs, which the browser opens (`minio` is compose-only).
+    - S3_PROXY_URL=${S3_PROXY_URL:-}
     - SERVER_NAME=${SERVER_NAME}
     - PLATFORM_URL=${PLATFORM_URL:-http://localhost:8080}
     - TEMPORAL_API_URL=${TEMPORAL_API_URL:-}

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -30,7 +30,7 @@ def test_s3_bucket(s3_client):
     response = s3_client.list_buckets()
     bucket_names = [bucket["Name"] for bucket in response["Buckets"]]
 
-    # pyro-api creates one bucket per organization, named {SERVER_NAME}-alert-api-{org_id}
+    # One bucket per organization: {SERVER_NAME}-alert-api-{org_id}
     alert_buckets = [name for name in bucket_names if name.endswith("-alert-api-1")]
     assert alert_buckets, bucket_names
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -6,8 +6,8 @@ import pytest
 # Load environment variables from .env file
 load_dotenv()
 
-# Get S3 endpoint URL and credentials from environment variables
-s3_endpoint_url = os.getenv("S3_ENDPOINT_URL") + "/"
+# Tests run on the host: prefer the public endpoint, `minio` is compose-only.
+s3_endpoint_url = (os.getenv("S3_PROXY_URL") or os.getenv("S3_ENDPOINT_URL")) + "/"
 s3_access_key = os.getenv("S3_ACCESS_KEY")
 s3_secret_key = os.getenv("S3_SECRET_KEY")
 s3_region = os.getenv("S3_REGION")
@@ -28,10 +28,13 @@ def s3_client():
 
 def test_s3_bucket(s3_client):
     response = s3_client.list_buckets()
-    assert response["Buckets"][0]["Name"] == "admin"
-    assert response["Buckets"][1]["Name"].endswith("-alert-api-1")
+    bucket_names = [bucket["Name"] for bucket in response["Buckets"]]
 
-    bucket_contents = s3_client.list_objects_v2(Bucket=response["Buckets"][1]["Name"])
+    # pyro-api creates one bucket per organization, named {SERVER_NAME}-alert-api-{org_id}
+    alert_buckets = [name for name in bucket_names if name.endswith("-alert-api-1")]
+    assert alert_buckets, bucket_names
+
+    bucket_contents = s3_client.list_objects_v2(Bucket=alert_buckets[0])
     print(bucket_contents)
     [item["Key"] for item in bucket_contents.get("Contents", [])]
     # assert keys != []


### PR DESCRIPTION
## Problem

Setting up this env requires adding `127.0.0.1 minio` to the machine's hosts file. It needs `sudo`, it hijacks the name `minio` for every project on that machine, and it is especially awkward on Windows.

`pyro-api` builds presigned image URLs from `S3_ENDPOINT_URL` (`http://minio:9000`). That host only resolves inside the compose network, but the URLs are opened by the browser on the host — so without the hosts entry the alert images fail with `ERR_NAME_NOT_RESOLVED`.

## Fix

`pyro-api` already supports `S3_PROXY_URL`, which rewrites the host of presigned URLs ([`storage.py`](https://github.com/pyronear/pyro-api/blob/main/src/app/services/storage.py)). This repo simply never passed it. Setting it to `http://localhost:9000` — the port MinIO already publishes — makes presigned URLs loadable from the host, and the hosts entry can go.

Internal consumers (`pyro_api`, `temporal_model_api`) keep talking to `minio:9000` over the compose network; only browser-facing URLs are rewritten.

No new service, no extra port.

## Why this works (and when it would stop)

`boto3` presigns with **SigV2** here (`AWSAccessKeyId=...&Signature=...`), and SigV2 does not cover the `Host` header, so rewriting the host keeps the signature valid. Measured on the same object:

| Signature version | Host rewrite |
|---|---|
| default (what pyro-api uses) → SigV2 | `200` |
| forced SigV2 | `200` |
| forced SigV4 | `403 SignatureDoesNotMatch` |

MinIO is not being lenient — it validates correctly (unsigned and tampered requests both return `403`). This is noted in `.env.test`: **if the S3 backend or boto3's default ever requires SigV4, this needs a Host-rewriting reverse proxy instead.** Worth keeping in mind for a move off MinIO, whose repo is now archived — Garage, for instance, only accepts SigV4.

## Also in here

`tests/test_media.py` runs on the host and had the same dependency, so it prefers the public endpoint too.

Its bucket assertions were stale: they expected a literal `admin` bucket, from before the `SERVER_NAME` prefix. Real buckets are `{SERVER_NAME}-alert-api-{org_id}`. This failure is pre-existing and endpoint-independent — it just was never reached, since the test failed earlier at connection time. Assertions rewritten against the actual naming.

## Verification

Run with **no** `minio` entry in `/etc/hosts` (`ping minio` → `cannot resolve minio`):

- `make run` → all services healthy, `init` reports 0 errors
- upload a detection, then `GET /api/v1/detections/{id}/url` → `200`, URL host is `localhost:9000`
- fetching that URL from the host → `200`, bytes identical to the uploaded image
- the frontend bundle contains no hardcoded S3 host, so it uses the URL the API returns
- `pytest tests/test_media.py` → passes

Not covered: `tests/test_alerts.py` could not run on my machine — a local PostgreSQL occupies `127.0.0.1:5432` ahead of the Docker binding, so it queries the wrong database. Unrelated to S3 and untouched here.

## Upgrading

The `127.0.0.1 minio` line is harmless if left in place; existing setups keep working either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
